### PR TITLE
Add scss and markdown filter language recognition

### DIFF
--- a/Syntaxes/Pug.JSON-tmLanguage
+++ b/Syntaxes/Pug.JSON-tmLanguage
@@ -98,6 +98,16 @@
       ]
     },
     {
+      "begin": "^(\\s*):(scss)(?=\\(|$)",
+      "beginCaptures": { "2": { "name": "constant.language.name.scss.filter.pug" } },
+      "end": "^(?!(\\1\\s)|\\s*$)",
+      "name": "source.scss.filter.pug",
+      "patterns": [
+        { "include": "#tag_attributes" },
+        { "include": "source.scss" }
+      ]
+    },
+    {
       "begin": "^(\\s*):(less)(?=\\(|$)",
       "beginCaptures": { "2": { "name": "constant.language.name.less.filter.pug" } },
       "end": "^(?!(\\1\\s)|\\s*$)",
@@ -124,6 +134,16 @@
       "patterns": [
         { "include": "#tag_attributes" },
         { "include": "source.coffee" }
+      ]
+    },
+    {
+      "begin": "^(\\s*):(markdown|md)?)(?=\\(|$)",
+      "beginCaptures": { "2": { "name": "constant.language.name.markdown.filter.pug" } },
+      "end": "^(?!(\\1\\s)|\\s*$)",
+      "name": "source.markdown.filter.pug",
+      "patterns": [
+        { "include": "#tag_attributes" },
+        { "include": "source.markdown" }
       ]
     },
     {


### PR DESCRIPTION
This might be quite naive -- I don't know what else needs to be done to build and/or test this, but it seemed that by adding the right blocks in the `.JSON-tmLanguage` file these mappings could be established. My desire is to eventually have the vscode people pull this through to their language extension too (currently they are mapped to your older extension, `jade-tmbundle`).

Please give me some pointers, if it requires more work.