### PR TITLE
allow module type javascript block syntax

### DIFF
--- a/Syntaxes/Pug.JSON-tmLanguage
+++ b/Syntaxes/Pug.JSON-tmLanguage
@@ -48,7 +48,7 @@
       ]
     },
     {
-      "begin": "^(\\s*)(script)((\\.$)|(?=[^\\n]*(text|application)/javascript.*\\.$))",
+      "begin": "^(\\s*)(script)((\\.$)|(?=[^\\n]*((text|application)/javascript|module).*\\.$))",
       "beginCaptures": { "2": { "name": "entity.name.tag.pug" } },
       "end": "^(?!(\\1\\s)|\\s*$)",
       "name": "meta.tag.other",


### PR DESCRIPTION
I couldn't figure out how to test the change with the files in this repository, but I tried copying the change into `C:\Users\<user>\AppData\Local\Programs\Microsoft VS Code\resources\app\extensions\pug\syntaxes\pug.tmLanguage.json` then restarting VSCode. It seemed to be working well as far as I can see.

Let me know if I missed something 😀

Fixes #30